### PR TITLE
feat: add ability to define own loads function for meatie_aiohttp client

### DIFF
--- a/src/meatie_aiohttp/client.py
+++ b/src/meatie_aiohttp/client.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any, Optional
 
 import aiohttp
+from aiohttp.typedefs import DEFAULT_JSON_DECODER, JSONDecoder
 from meatie import (
     AsyncResponse,
     BaseAsyncClient,
@@ -31,6 +32,10 @@ class Client(BaseAsyncClient):
 
         self.session = session
         self.session_params = session_params if session_params else {}
+
+    @classmethod
+    def loads(cls) -> JSONDecoder:
+        return DEFAULT_JSON_DECODER
 
     async def send(self, request: Request) -> AsyncResponse:
         kwargs: dict[str, Any] = self.session_params.copy()
@@ -66,7 +71,7 @@ class Client(BaseAsyncClient):
             raise TransportError(exc) from exc
         except Exception as exc:
             raise MeatieError(exc) from exc
-        return Response(response)
+        return Response(response, loads=self.loads())
 
     async def __aexit__(
         self,

--- a/src/meatie_aiohttp/response.py
+++ b/src/meatie_aiohttp/response.py
@@ -4,12 +4,16 @@ from json.decoder import JSONDecodeError
 from typing import Any, Literal, Optional
 
 from aiohttp import ClientResponse, ContentTypeError
+from aiohttp.typedefs import DEFAULT_JSON_DECODER, JSONDecoder
 from meatie.error import ParseResponseError, ResponseError
 
 
 class Response:
-    def __init__(self, response: ClientResponse) -> None:
+    def __init__(
+        self, response: ClientResponse, *, loads: JSONDecoder = DEFAULT_JSON_DECODER
+    ) -> None:
         self.response = response
+        self.loads = loads
 
     @property
     def status(self) -> int:
@@ -40,7 +44,7 @@ class Response:
 
     async def json(self) -> dict[str, Any]:
         try:
-            return await self.response.json()
+            return await self.response.json(loads=self.loads)
         except JSONDecodeError as exc:
             text = await self._text()
             raise ParseResponseError(text, self, exc) from exc

--- a/tests/client/aiohttp_/adapter/test_json.py
+++ b/tests/client/aiohttp_/adapter/test_json.py
@@ -1,5 +1,8 @@
 #  Copyright 2024 The Meatie Authors. All rights reserved.
 #  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+import json
+from decimal import Decimal
+from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler
 
@@ -7,6 +10,7 @@ import pytest
 from http_test import HTTPTestServer
 from meatie import ParseResponseError, endpoint
 from meatie_aiohttp import Client
+from typing_extensions import override
 
 
 @pytest.mark.asyncio()
@@ -85,3 +89,35 @@ async def test_can_handle_corrupted_json(http_server: HTTPTestServer) -> None:
     # THEN
     exc = exc_info.value
     assert HTTPStatus.OK == exc.response.status
+
+
+@pytest.mark.asyncio()
+async def test_can_configure_json_loads(http_server: HTTPTestServer) -> None:
+    # GIVEN response have json which will lose precision if parsed as float
+    raw_json = '{"foo": 42.000000000000001}'
+    assert json.dumps(json.loads(raw_json)) != raw_json
+
+    def handler(request: BaseHTTPRequestHandler) -> None:
+        request.send_response(HTTPStatus.OK)
+        request.send_header("Content-Type", "application/json")
+        request.end_headers()
+        request.wfile.write(raw_json.encode("utf-8"))
+
+    http_server.handler = handler
+
+    class TestClient(Client):
+        @classmethod
+        @override
+        def loads(cls) -> json.JSONDecoder:
+            return partial(json.loads, parse_float=Decimal)
+
+        @endpoint("/")
+        async def get_response(self) -> dict[str, Decimal]:
+            ...
+
+    # WHEN
+    async with TestClient(http_server.create_session()) as client:
+        response = await client.get_response()
+
+    # THEN
+    assert {"foo": Decimal("42.000000000000001")} == response


### PR DESCRIPTION
i did consider to add `loads` as parameter to `Client` init, but because it's impact return types of endpoint - added class method