### PR TITLE
:sparkles: Add conditional logic to path templates

### DIFF
--- a/src/meatie/internal/template/path.py
+++ b/src/meatie/internal/template/path.py
@@ -1,43 +1,92 @@
-#  Copyright 2024 The Meatie Authors. All rights reserved.
-#  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
-
 import re
-from typing import (
-    Any,
-)
+from typing import Any
 
 from typing_extensions import Self
 
-_param_pattern = re.compile(r"{(?P<name>[a-zA-Z_]\w*?)}")
+_param_pattern = re.compile(r"{(?P<name>[a-zA-Z_]\w*?)}")  # Matches {name} for parameters
+_cond_pattern = re.compile(
+    r"\[(?P<name>[a-zA-Z_]\w*?)(?::(?P<content>[^]]+))?\]"
+)  # Matches [name] and [name:content]
 
 
 class PathTemplate:
-    __slots__ = ("template", "parameters")
+    """
+    A template class for constructing and formatting paths with dynamic parameters
+    and conditionally included content.
 
-    def __init__(self, template: str, parameters: list[str]) -> None:
-        self.template = template
-        self.parameters = parameters
+    Example:
+        template = PathTemplate.from_string("/{endpoint}/[all]/[event:events]")
+        result = template.format(endpoint="users", all=True, event=False)
+        # result -> "/users/all/"
+    """
+
+    __slots__ = ("template", "parameters", "conditionals")
+
+    def __init__(self, template: str, parameters: list[str], conditionals: dict[str, str]) -> None:
+        self.template = template  # Raw template string
+        self.parameters = parameters  # List of {name} parameters
+        self.conditionals = conditionals  # Dictionary of [name] or [name:content] conditionals
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, PathTemplate):
-            return self.template == other.template and self.parameters == other.parameters
+            return (
+                self.template == other.template
+                and self.parameters == other.parameters
+                and self.conditionals == other.conditionals
+            )
         if isinstance(other, str):
             return self.template == other
         return False
 
-    def __hash__(self) -> int:
+    def __contains__(self, item: str) -> bool:
+        return item in self.parameters or item in self.conditionals
+
+    def __hash__(self):
         return hash(self.template)
 
-    def __contains__(self, item: str) -> bool:
-        return item in self.parameters
-
-    def __str__(self) -> str:
+    def __str__(self):
         return self.template
 
     def format(self, **kwargs: dict[str, Any]) -> str:
-        return self.template.format(**kwargs)
+        """Substitute parameters and handle conditional insertions within the template."""
+
+        missing_params = [param for param in self.parameters if param not in kwargs]
+        # Missing conditionals will just be False
+        if missing_params:
+            raise KeyError(
+                f"Missing required parameters or conditionals: {', '.join(missing_params)}"
+            )
+
+        result = self.template
+        result = self._process_conditionals(result, kwargs)
+        return result.format(**kwargs)
+
+    def _process_conditionals(self, result: str, kwargs: dict[str, Any]) -> str:
+        """Process conditional patterns based on provided arguments."""
+        for name, content in self.conditionals.items():
+            pattern = f"[{name}]" if not content else f"[{name}:{content}]"
+            result = self._replace_conditional(result, pattern, name, content, kwargs)
+        return result
+
+    def _replace_conditional(
+        self, result: str, pattern: str, name: str, content: str, kwargs: dict[str, Any]
+    ) -> str:
+        """Replace or remove a conditional pattern based on its truthiness."""
+        if kwargs.get(name, False):
+            to_insert = content or name
+            return re.sub(rf"(/?){re.escape(pattern)}(/?)", r"\1" + to_insert + r"\2", result)
+        return re.sub(
+            rf"(/?){re.escape(pattern)}(/?)",
+            lambda m: "/" if m.group(1) and m.group(2) else "",
+            result,
+        )
 
     @classmethod
     def from_string(cls, template: str) -> Self:
+        """Create a PathTemplate instance from a template string."""
         parameters = [match.group("name") for match in _param_pattern.finditer(template)]
-        return cls(template, parameters)
+        conditionals = {
+            match.group("name"): match.group("content") or ""
+            for match in _cond_pattern.finditer(template)
+        }
+        return cls(template, parameters, conditionals)

--- a/tests/internal/template/test_path_template.py
+++ b/tests/internal/template/test_path_template.py
@@ -1,0 +1,103 @@
+import pytest
+from meatie.internal.template import PathTemplate
+
+
+def test_basic_parameter_substitution():
+    template = PathTemplate.from_string("/{endpoint}")
+    assert template.format(endpoint="users") == "/users"
+    assert template.parameters == ["endpoint"]
+    assert template.conditionals == {}
+
+
+def test_conditional_flag_simple():
+    template = PathTemplate.from_string("/{endpoint}/[all]")
+    # Flag is False - should omit the conditional part
+    assert template.format(endpoint="users", all=False) == "/users"
+    # Flag is True - should include the flag name
+    assert template.format(endpoint="users", all=True) == "/users/all"
+    assert template.parameters == ["endpoint"]
+    assert template.conditionals == {"all": ""}
+
+
+def test_conditional_with_content():
+    template = PathTemplate.from_string("/{endpoint}/[event:events]")
+    # Flag is False - should omit the conditional part
+    assert template.format(endpoint="users", event=False) == "/users"
+    # Flag is True - should include the specified content
+    assert template.format(endpoint="users", event=True) == "/users/events"
+    assert template.parameters == ["endpoint"]
+    assert template.conditionals == {"event": "events"}
+
+
+def test_multiple_conditionals():
+    template = PathTemplate.from_string("/{endpoint}/[all]/[event:events]")
+    # Test all combinations
+    assert template.format(endpoint="users", all=False, event=False) == "/users"
+    assert template.format(endpoint="users", all=True, event=False) == "/users/all"
+    assert template.format(endpoint="users", all=False, event=True) == "/users/events"
+    assert template.format(endpoint="users", all=True, event=True) == "/users/all/events"
+    assert template.parameters == ["endpoint"]
+    assert template.conditionals == {"all": "", "event": "events"}
+
+
+def test_multiple_parameters():
+    template = PathTemplate.from_string("/{version}/{endpoint}/[all]")
+    assert template.format(version="v1", endpoint="users", all=True) == "/v1/users/all"
+    assert template.parameters == ["version", "endpoint"]
+    assert template.conditionals == {"all": ""}
+
+
+def test_equality():
+    template1 = PathTemplate.from_string("/{endpoint}/[all]")
+    template2 = PathTemplate.from_string("/{endpoint}/[all]")
+    template3 = PathTemplate.from_string("/{endpoint}/[event:events]")
+
+    assert template1 == template2
+    assert template1 != template3
+    assert template1 == "/{endpoint}/[all]"
+    assert template1 != "different"
+
+
+def test_contains():
+    template = PathTemplate.from_string("/{version}/{endpoint}/[all]/[event:events]")
+    assert "version" in template
+    assert "endpoint" in template
+    assert "all" in template
+    assert "event" in template
+    assert "nonexistent" not in template
+
+
+def test_missing_required_parameter():
+    template = PathTemplate.from_string("/{endpoint}/[all]")
+    with pytest.raises(KeyError):
+        template.format(all=True)  # Missing required 'endpoint' parameter
+
+
+def test_extra_parameters():
+    template = PathTemplate.from_string("/{endpoint}")
+    # Extra parameters should be ignored
+    assert template.format(endpoint="users", extra="ignored") == "/users"
+
+
+def test_falsy_values():
+    template = PathTemplate.from_string("/{endpoint}/[flag1]/[flag2:custom]")
+    # Test with various falsy values
+    assert template.format(endpoint="users", flag1=None, flag2=None) == "/users"
+    assert template.format(endpoint="users", flag1=0, flag2=0) == "/users"
+    assert template.format(endpoint="users", flag1="", flag2="") == "/users"
+    assert template.format(endpoint="users", flag1=[], flag2=[]) == "/users"
+
+
+def test_truthy_values():
+    template = PathTemplate.from_string("/{endpoint}/[flag1]/[flag2:custom]")
+    # Test with various truthy values
+    assert template.format(endpoint="users", flag1=1, flag2=1) == "/users/flag1/custom"
+    assert template.format(endpoint="users", flag1="yes", flag2="yes") == "/users/flag1/custom"
+    assert template.format(endpoint="users", flag1=[1], flag2=[1]) == "/users/flag1/custom"
+
+
+def test_empty_template():
+    template = PathTemplate.from_string("")
+    assert template.format() == ""
+    assert template.parameters == []
+    assert template.conditionals == {}


### PR DESCRIPTION
This implements the feature of conditional path templates suggested in #110.

Basically, this adds the "[arg]" and the "[arg:content]" syntax which will get substituted in if arg is True.