### PR TITLE
:memo: Add class documentation to the submodules.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ ignore = ["D100", "D105"]
 convention = "google"
 
 [tool.ruff.lint.flake8-copyright]
-notice-rgx = "(?i)Copyright \\d{4} The Meatie Authors. All rights reserved.\\n#  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.\\n"
+notice-rgx = "(?i)Copyright \\d{4} The Meatie Authors. All rights reserved.[\\r\\n]+#  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.[\\r\\n]*"
 min-file-size = 1024
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/meatie/client.py
+++ b/src/meatie/client.py
@@ -19,7 +19,7 @@ class BaseClient:
         local_cache: Optional[Cache] = None,
         limiter: Optional[Limiter] = None,
     ):
-        """Creates a BaseAsyncClient.
+        """Creates a BaseClient.
 
         Args:
             local_cache: Cache implementation for storing the HTTP responses.

--- a/src/meatie_aiohttp/__init__.py
+++ b/src/meatie_aiohttp/__init__.py
@@ -1,6 +1,8 @@
 #  Copyright 2024 The Meatie Authors. All rights reserved.
 #  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+"""Aiohttp client implementation for meatie."""
+
 # isort:skip_file
 from .response import Response
 from .client import Client

--- a/src/meatie_aiohttp/client.py
+++ b/src/meatie_aiohttp/client.py
@@ -22,6 +22,8 @@ from . import Response
 
 
 class Client(BaseAsyncClient):
+    """The async client implementation for aiohttp."""
+
     def __init__(
         self,
         session: aiohttp.ClientSession,

--- a/src/meatie_aiohttp/response.py
+++ b/src/meatie_aiohttp/response.py
@@ -6,9 +6,12 @@ from typing import Any, Awaitable, Callable, Optional
 from aiohttp import ClientError, ClientResponse, ContentTypeError
 
 from meatie.error import ParseResponseError, ResponseError
+from meatie.types import AsyncResponse as BaseAsyncResponse
 
 
-class Response:
+class Response(BaseAsyncResponse):
+    """The async response implementation for aiohttp."""
+
     def __init__(
         self,
         response: ClientResponse,

--- a/src/meatie_httpx/__init__.py
+++ b/src/meatie_httpx/__init__.py
@@ -1,6 +1,8 @@
 #  Copyright 2024 The Meatie Authors. All rights reserved.
 #  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+"""Httpx client implementation for meatie, with sync and async versions."""
+
 # isort:skip_file
 from .response import Response
 from .client import Client

--- a/src/meatie_httpx/async_client.py
+++ b/src/meatie_httpx/async_client.py
@@ -22,6 +22,8 @@ from .client import build_kwargs
 
 
 class AsyncClient(BaseAsyncClient):
+    """The async client implementation for httpx."""
+
     def __init__(
         self,
         client: httpx.AsyncClient,

--- a/src/meatie_httpx/async_response.py
+++ b/src/meatie_httpx/async_response.py
@@ -6,9 +6,12 @@ from typing import Any, Awaitable, Callable, Optional
 import httpx
 
 from meatie.error import ParseResponseError, ResponseError
+from meatie.types import AsyncResponse as BaseAsyncResponse
 
 
-class AsyncResponse:
+class AsyncResponse(BaseAsyncResponse):
+    """The async response implementation using httpx."""
+
     def __init__(
         self,
         response: httpx.Response,

--- a/src/meatie_httpx/client.py
+++ b/src/meatie_httpx/client.py
@@ -20,6 +20,8 @@ from . import Response
 
 
 class Client(BaseClient):
+    """The sync client implementation using httpx."""
+
     def __init__(
         self,
         client: httpx.Client,

--- a/src/meatie_httpx/response.py
+++ b/src/meatie_httpx/response.py
@@ -6,9 +6,12 @@ from typing import Any, Callable, Optional
 import httpx
 
 from meatie.error import ParseResponseError, ResponseError
+from meatie.types import Response as BaseResponse
 
 
-class Response:
+class Response(BaseResponse):
+    """The sync response implementation using httpx."""
+
     def __init__(
         self,
         response: httpx.Response,

--- a/src/meatie_requests/__init__.py
+++ b/src/meatie_requests/__init__.py
@@ -1,6 +1,8 @@
 #  Copyright 2024 The Meatie Authors. All rights reserved.
 #  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+"""Requests client implementation for meatie."""
+
 # isort:skip_file
 from .response import Response
 from .client import Client

--- a/src/meatie_requests/client.py
+++ b/src/meatie_requests/client.py
@@ -20,6 +20,8 @@ from . import Response
 
 
 class Client(BaseClient):
+    """The sync client implementation using requests."""
+
     def __init__(
         self,
         session: Session,

--- a/src/meatie_requests/response.py
+++ b/src/meatie_requests/response.py
@@ -8,6 +8,8 @@ from meatie.error import ParseResponseError, ResponseError
 
 
 class Response:
+    """The sync response implementation using requests."""
+
     def __init__(
         self,
         response: requests.Response,

--- a/src/meatie_requests/response.py
+++ b/src/meatie_requests/response.py
@@ -5,9 +5,10 @@ from typing import Any, Callable, Optional
 import requests
 
 from meatie.error import ParseResponseError, ResponseError
+from meatie.types import Response as BaseResponse
 
 
-class Response:
+class Response(BaseResponse):
     """The sync response implementation using requests."""
 
     def __init__(

--- a/tests/examples/aiohttp/tutorial/test_json.py
+++ b/tests/examples/aiohttp/tutorial/test_json.py
@@ -1,3 +1,6 @@
+#  Copyright 2024 The Meatie Authors. All rights reserved.
+#  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
 import json
 from typing import Annotated, Any
 

--- a/tests/examples/aiohttp/tutorial/test_private.py
+++ b/tests/examples/aiohttp/tutorial/test_private.py
@@ -1,3 +1,6 @@
+#  Copyright 2024 The Meatie Authors. All rights reserved.
+#  Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+
 from typing import Annotated, override
 
 import pytest


### PR DESCRIPTION
Also added explicit inheritance to response classes to inherit the docstrings.

Most decent python editors can infer them (tested on PyCharm), but I was looking at [this](https://stackoverflow.com/a/2025581/22478603) stackoverflow answer which shows a recipe for inheriting docstrings. I suppose it is not necessary, what do you think about that?

Also, I’m encountering an issue where `CPY001` fails 91 times on my local machine but passes without any issues in CI. This might be related to `ruff` — could be a bug or a system-specific quirk. Because of that, I am wondering:

- Is ruff passing on your machine?
- If so, could you let me know which OS you're using? (I’m on Windows, which might be the culprit.)

Lastly, are the docs already hosted or did you just do the frameworking? I found a great guide of how to publish using github actions [here](https://squidfunk.github.io/mkdocs-material/publishing-your-site/)

Thanks for your input and support! 🙏🏼 